### PR TITLE
wording / typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ qrono({ localtime: true }, '2021-08-31 12:34').toString() === '2021-08-31T12:34.
 ## Design philosophy 🎨
 
 - Provides immutable and chain-able functions that are necessary in most cases.
-- Not support localization.
+- Locality-Agnostic.
   - It could be done with [ECMAScript® Internationalization API](https://402.ecma-international.org/#overview).
 - Supports only UTC (as default) and local time of the environment.
   - [Other libraries](#alternatives) tend to have bigger code base and complicated usage to support multiple time zones and locales.


### PR DESCRIPTION
文法ツッコミです。(文法警察ではありませんのでスルー可) 

Not support**ing** か No support for でも良さそうですが、地域差を「サポートしない」というより「依存しない」という点に積極的な意図を感じましたので "agnostic" を使ってみました。

あんまりこういう指摘はしないタチなのですが、ここが本ライブラリのセールスポイントだと感じましたのでreadme冒頭でのミスはもったいないと思いPRさせてもらいました。お気に召さば。